### PR TITLE
Upgrade Golangci-lint to v1.50.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -83,7 +82,6 @@ linters:
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
   # don't enable:
   # - asciicheck
@@ -122,6 +120,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.48.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.50.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/examples/basic/.golangci.yml
+++ b/examples/basic/.golangci.yml
@@ -51,7 +51,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -83,7 +82,6 @@ linters:
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
   # don't enable:
   # - asciicheck
@@ -122,6 +120,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.48.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.50.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/pkg/export/.golangci.yml
+++ b/pkg/export/.golangci.yml
@@ -51,7 +51,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -83,7 +82,6 @@ linters:
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
   # don't enable:
   # - asciicheck
@@ -122,6 +120,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.48.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.50.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/pkg/lib/.golangci.yml
+++ b/pkg/lib/.golangci.yml
@@ -51,7 +51,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -83,7 +82,6 @@ linters:
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
   # don't enable:
   # - asciicheck
@@ -122,6 +120,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.48.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.50.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.50.0

Related to: https://github.com/test-network-function/cnf-certification-test/pull/604