### PR TITLE
Upgrade Go to v1.20.1

### DIFF
--- a/examples/basic/go.mod
+++ b/examples/basic/go.mod
@@ -1,6 +1,6 @@
 module github.com/test-network-function/simplegraphsolver/examples/basic
 
-go 1.19
+go 1.20
 
 replace github.com/test-network-function/simplegraphsolver/pkg/lib => ../../pkg/lib
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/test-network-function/l2discovery-examples
 
-go 1.19
+go 1.20
 
 require (
 	github.com/openshift/ptp-operator v0.0.0-20220922002031-4e588c96d5d6

--- a/pkg/export/go.mod
+++ b/pkg/export/go.mod
@@ -1,6 +1,6 @@
 module github.com/test-network-function/simplegraphsolver/pkg/export
 
-go 1.19
+go 1.20
 
 replace github.com/test-network-function/l2discovery/l2lib/pkg/export => ../../../l2discoverydavid/l2lib/pkg/export
 

--- a/pkg/lib/go.mod
+++ b/pkg/lib/go.mod
@@ -1,6 +1,6 @@
 module github.com/test-network-function/simplegraphsolver/pkg/lib
 
-go 1.19
+go 1.20
 
 replace github.com/test-network-function/simplegraphsolver/pkg/export => ../export
 


### PR DESCRIPTION
Release Notes: https://tip.golang.org/doc/go1.20

Related to: https://github.com/test-network-function/cnf-certification-test/pull/873